### PR TITLE
Fix speed initialization in LowEnemy constructor

### DIFF
--- a/LowEnemy.java
+++ b/LowEnemy.java
@@ -6,6 +6,7 @@ private int speed;
 
 public LowEnemy(int startX, int startY, int width, int height, int speed) {
     body = new Rectangle(startX, startY, width, height);
+    this.speed = speed;
 }
 
 public void move(int[][] map) {


### PR DESCRIPTION
## Summary
- ensure the LowEnemy constructor sets its `speed` field

## Testing
- `javac -version`
- `javac -Xlint:unchecked *.java` *(fails: non-static variable dx/dy cannot be referenced from a static context)*

------
https://chatgpt.com/codex/tasks/task_e_684896801d8c832cbaece0bfceec0627